### PR TITLE
When using -C colourful mode, index out of range is thrown

### DIFF
--- a/CuteR/CuteR.py
+++ b/CuteR/CuteR.py
@@ -144,9 +144,9 @@ def main():
         if args.rgba:
           rgba = tuple(args.rgba)
         else:
-            rgba = (0,0,0)
+            rgba = (0,0,0,255)
     else:
-        rgba = (0,0,0)
+        rgba = (0,0,0,255)
     produce(txt,img,ver,ec,bri, cont ,colourful = colr,rgba=rgba,pixelate = pixelate).save(output)
 
 if __name__ == "__main__":


### PR DESCRIPTION
As the values were changed to rgba, the `a` was missing in the input tuple. This corrects it for me, in my limited testing.